### PR TITLE
Add MIT License section to README and copyright headers to all source…

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,3 +349,7 @@ If you are interested in other runtime environments, please open or upvote an is
 ## Contributing
 
 See [the contributing documentation](./CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/scripts/utils/check-is-in-git-install.sh
+++ b/scripts/utils/check-is-in-git-install.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
 # Check if you happen to call prepare for a repository that's already in node_modules.
 [ "$(basename "$(dirname "$PWD")")" = 'node_modules' ] ||
 # The name of the containing directory that 'npm` uses, which looks like

--- a/scripts/utils/git-swap.sh
+++ b/scripts/utils/git-swap.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
 set -exuo pipefail
 # the package is published to NPM from ./dist
 # we want the final file structure for git installs to match the npm installs, so we

--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
 set -exuo pipefail
 
 RESPONSE=$(curl -X POST "$URL" \

--- a/src/_shims/MultipartBody.ts
+++ b/src/_shims/MultipartBody.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/runtime-bun.ts
+++ b/src/_shims/auto/runtime-bun.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/runtime-deno.ts
+++ b/src/_shims/auto/runtime-deno.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/runtime-node.ts
+++ b/src/_shims/auto/runtime-node.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/runtime.ts
+++ b/src/_shims/auto/runtime.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/types-deno.ts
+++ b/src/_shims/auto/types-deno.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/types-node.ts
+++ b/src/_shims/auto/types-node.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/types.d.ts
+++ b/src/_shims/auto/types.d.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/auto/types.js
+++ b/src/_shims/auto/types.js
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/bun-runtime.ts
+++ b/src/_shims/bun-runtime.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/index-deno.ts
+++ b/src/_shims/index-deno.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { MultipartBody } from './MultipartBody';
 import { type RequestOptions } from '../core';
 

--- a/src/_shims/index.d.ts
+++ b/src/_shims/index.d.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/index.js
+++ b/src/_shims/index.js
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/manual-types.d.ts
+++ b/src/_shims/manual-types.d.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/manual-types.js
+++ b/src/_shims/manual-types.js
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/node-runtime.ts
+++ b/src/_shims/node-runtime.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/node-types.d.ts
+++ b/src/_shims/node-types.d.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/node-types.js
+++ b/src/_shims/node-types.js
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/registry.ts
+++ b/src/_shims/registry.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/web-runtime.ts
+++ b/src/_shims/web-runtime.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/web-types.d.ts
+++ b/src/_shims/web-types.d.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/_shims/web-types.js
+++ b/src/_shims/web-types.js
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { VERSION } from './version';
 import { Stream } from './streaming';
 import {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { castToError, Headers } from './core';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { type Agent } from './_shims/index';

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { LlamaStackClientError } from '../../error';
 
 export type Bytes = string | ArrayBuffer | Uint8Array | Buffer | null | undefined;

--- a/src/internal/qs/formats.ts
+++ b/src/internal/qs/formats.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import type { Format } from './types';
 
 export const default_format: Format = 'RFC3986';

--- a/src/internal/qs/index.ts
+++ b/src/internal/qs/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { default_format, formatters, RFC1738, RFC3986 } from './formats';
 
 const formats = {

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { encode, is_buffer, maybe_map } from './utils';
 import { default_format, formatters } from './formats';
 import type { NonNullableProperties, StringifyOptions } from './types';

--- a/src/internal/qs/types.ts
+++ b/src/internal/qs/types.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 export type Format = 'RFC1738' | 'RFC3986';
 
 export type DefaultEncoder = (str: any, defaultEncoder?: any, charset?: string) => string;

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { RFC1738 } from './formats';
 import type { DefaultEncoder, Format } from './types';
 

--- a/src/internal/stream-utils.ts
+++ b/src/internal/stream-utils.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 /**
  * Most browsers don't yet have async iterable support for ReadableStream,
  * and Node has a very different way of reading bytes from its "ReadableStream".

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { AbstractPage, Response, APIClient, FinalRequestOptions, PageInfo } from './core';

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import type { LlamaStackClient } from './index';

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,1 +1,7 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 export * from './resources/index';

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './agents/index';

--- a/src/resources/agents/agents.ts
+++ b/src/resources/agents/agents.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/agents/index.ts
+++ b/src/resources/agents/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export {

--- a/src/resources/agents/session.ts
+++ b/src/resources/agents/session.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/agents/steps.ts
+++ b/src/resources/agents/steps.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/agents/turn.ts
+++ b/src/resources/agents/turn.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/benchmarks.ts
+++ b/src/resources/benchmarks.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/chat.ts
+++ b/src/resources/chat.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './chat/index';

--- a/src/resources/chat/chat.ts
+++ b/src/resources/chat/chat.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/chat/completions.ts
+++ b/src/resources/chat/completions.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/chat/index.ts
+++ b/src/resources/chat/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export { Chat, type ChatCompletionChunk } from './chat';

--- a/src/resources/completions.ts
+++ b/src/resources/completions.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/datasets.ts
+++ b/src/resources/datasets.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/embeddings.ts
+++ b/src/resources/embeddings.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/eval.ts
+++ b/src/resources/eval.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './eval/index';

--- a/src/resources/eval/eval.ts
+++ b/src/resources/eval/eval.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/eval/index.ts
+++ b/src/resources/eval/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export {

--- a/src/resources/eval/jobs.ts
+++ b/src/resources/eval/jobs.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/files.ts
+++ b/src/resources/files.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './shared';

--- a/src/resources/inference.ts
+++ b/src/resources/inference.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/inspect.ts
+++ b/src/resources/inspect.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/models.ts
+++ b/src/resources/models.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './models/index';

--- a/src/resources/models/index.ts
+++ b/src/resources/models/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export {

--- a/src/resources/models/models.ts
+++ b/src/resources/models/models.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/models/openai.ts
+++ b/src/resources/models/openai.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/moderations.ts
+++ b/src/resources/moderations.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/post-training.ts
+++ b/src/resources/post-training.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './post-training/index';

--- a/src/resources/post-training/index.ts
+++ b/src/resources/post-training/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export {

--- a/src/resources/post-training/job.ts
+++ b/src/resources/post-training/job.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/post-training/post-training.ts
+++ b/src/resources/post-training/post-training.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/providers.ts
+++ b/src/resources/providers.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/responses.ts
+++ b/src/resources/responses.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './responses/index';

--- a/src/resources/responses/index.ts
+++ b/src/resources/responses/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export { InputItems, type InputItemListResponse, type InputItemListParams } from './input-items';

--- a/src/resources/responses/input-items.ts
+++ b/src/resources/responses/input-items.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/routes.ts
+++ b/src/resources/routes.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/safety.ts
+++ b/src/resources/safety.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/scoring-functions.ts
+++ b/src/resources/scoring-functions.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/scoring.ts
+++ b/src/resources/scoring.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import * as Shared from './shared';

--- a/src/resources/shields.ts
+++ b/src/resources/shields.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/synthetic-data-generation.ts
+++ b/src/resources/synthetic-data-generation.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/telemetry.ts
+++ b/src/resources/telemetry.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/tool-runtime.ts
+++ b/src/resources/tool-runtime.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './tool-runtime/index';

--- a/src/resources/tool-runtime/index.ts
+++ b/src/resources/tool-runtime/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export { RagTool, type RagToolInsertParams, type RagToolQueryParams } from './rag-tool';

--- a/src/resources/tool-runtime/rag-tool.ts
+++ b/src/resources/tool-runtime/rag-tool.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/tool-runtime/tool-runtime.ts
+++ b/src/resources/tool-runtime/tool-runtime.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/toolgroups.ts
+++ b/src/resources/toolgroups.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/tools.ts
+++ b/src/resources/tools.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/vector-dbs.ts
+++ b/src/resources/vector-dbs.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/vector-io.ts
+++ b/src/resources/vector-io.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../resource';

--- a/src/resources/vector-stores.ts
+++ b/src/resources/vector-stores.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export * from './vector-stores/index';

--- a/src/resources/vector-stores/files.ts
+++ b/src/resources/vector-stores/files.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/resources/vector-stores/index.ts
+++ b/src/resources/vector-stores/index.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 export {

--- a/src/resources/vector-stores/vector-stores.ts
+++ b/src/resources/vector-stores/vector-stores.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';

--- a/src/shims/node.ts
+++ b/src/shims/node.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // @ts-ignore
 import * as types from '../_shims/node-types';
 import { setShims } from '../_shims/registry';

--- a/src/shims/web.ts
+++ b/src/shims/web.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // @ts-ignore
 import * as types from '../_shims/web-types';
 import { setShims } from '../_shims/registry';

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { ReadableStream, type Response } from './_shims/index';
 import { LlamaStackClientError } from './error';
 import { findDoubleNewlineIndex, LineDecoder } from './internal/decoders/line';

--- a/src/uploads.ts
+++ b/src/uploads.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { type RequestOptions } from './core';
 import {
   FormData,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,7 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 export const VERSION = '0.2.23'; // x-release-please-version

--- a/tests/api-resources/agents/agents.test.ts
+++ b/tests/api-resources/agents/agents.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/agents/session.test.ts
+++ b/tests/api-resources/agents/session.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/agents/steps.test.ts
+++ b/tests/api-resources/agents/steps.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/agents/turn.test.ts
+++ b/tests/api-resources/agents/turn.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/benchmarks.test.ts
+++ b/tests/api-resources/benchmarks.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/chat/completions.test.ts
+++ b/tests/api-resources/chat/completions.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/completions.test.ts
+++ b/tests/api-resources/completions.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/datasets.test.ts
+++ b/tests/api-resources/datasets.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/eval/eval.test.ts
+++ b/tests/api-resources/eval/eval.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/eval/jobs.test.ts
+++ b/tests/api-resources/eval/jobs.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/files.test.ts
+++ b/tests/api-resources/files.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient, { toFile } from 'llama-stack-client';

--- a/tests/api-resources/inference.test.ts
+++ b/tests/api-resources/inference.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/inspect.test.ts
+++ b/tests/api-resources/inspect.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/models/models.test.ts
+++ b/tests/api-resources/models/models.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/models/openai.test.ts
+++ b/tests/api-resources/models/openai.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/moderations.test.ts
+++ b/tests/api-resources/moderations.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/post-training/job.test.ts
+++ b/tests/api-resources/post-training/job.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/post-training/post-training.test.ts
+++ b/tests/api-resources/post-training/post-training.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/providers.test.ts
+++ b/tests/api-resources/providers.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/responses/input-items.test.ts
+++ b/tests/api-resources/responses/input-items.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/responses/responses.test.ts
+++ b/tests/api-resources/responses/responses.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/routes.test.ts
+++ b/tests/api-resources/routes.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/safety.test.ts
+++ b/tests/api-resources/safety.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/scoring-functions.test.ts
+++ b/tests/api-resources/scoring-functions.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/scoring.test.ts
+++ b/tests/api-resources/scoring.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/shields.test.ts
+++ b/tests/api-resources/shields.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/synthetic-data-generation.test.ts
+++ b/tests/api-resources/synthetic-data-generation.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/telemetry.test.ts
+++ b/tests/api-resources/telemetry.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/tool-runtime/rag-tool.test.ts
+++ b/tests/api-resources/tool-runtime/rag-tool.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/tool-runtime/tool-runtime.test.ts
+++ b/tests/api-resources/tool-runtime/tool-runtime.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/toolgroups.test.ts
+++ b/tests/api-resources/toolgroups.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/tools.test.ts
+++ b/tests/api-resources/tools.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/vector-dbs.test.ts
+++ b/tests/api-resources/vector-dbs.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/vector-io.test.ts
+++ b/tests/api-resources/vector-io.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/vector-stores/files.test.ts
+++ b/tests/api-resources/vector-stores/files.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/api-resources/vector-stores/vector-stores.test.ts
+++ b/tests/api-resources/vector-stores/vector-stores.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { multipartFormRequestOptions, createForm } from 'llama-stack-client/core';
 import { Blob } from 'llama-stack-client/_shims/index';
 import { toFile } from 'llama-stack-client';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import LlamaStackClient from 'llama-stack-client';

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { findDoubleNewlineIndex, LineDecoder } from 'llama-stack-client/internal/decoders/line';
 
 function decodeChunks(chunks: string[], { flush }: { flush: boolean } = { flush: false }): string[] {

--- a/tests/qs/empty-keys-cases.ts
+++ b/tests/qs/empty-keys-cases.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 export const empty_test_cases = [
   {
     input: '&',

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import iconv from 'iconv-lite';
 import { stringify } from 'llama-stack-client/internal/qs';
 import { encode } from 'llama-stack-client/internal/qs/utils';

--- a/tests/qs/utils.test.ts
+++ b/tests/qs/utils.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { combine, merge, is_buffer, assign_single_source } from 'llama-stack-client/internal/qs/utils';
 
 describe('merge()', function () {

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { createResponseHeaders } from 'llama-stack-client/core';
 import { Headers } from 'llama-stack-client/_shims/index';
 

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import { Response } from 'node-fetch';
 import { PassThrough } from 'stream';
 import assert from 'assert';

--- a/tests/stringifyQuery.test.ts
+++ b/tests/stringifyQuery.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { LlamaStackClient } from 'llama-stack-client';

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import fs from 'fs';
 import { toFile, type ResponseLike } from 'llama-stack-client/uploads';
 import { File } from 'llama-stack-client/_shims/index';


### PR DESCRIPTION
… files

- Added License section to README.md referencing MIT License
- Added Meta Platforms copyright headers to 146 TypeScript and shell script files
- Ensures OSS compliance with Meta's requirements