### PR TITLE
feat: add integration tests CI workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,6 @@
 name: Integration Tests (Client-side)
 
-run-name: Run integration tests from llama-stack using local TypeScript client
+run-name: Run TypeScript client tests from llama-stack (replay mode)
 
 on:
   push:
@@ -102,7 +102,7 @@ jobs:
           free -h
           df -h
 
-      - name: Run Integration Tests (Replay Mode)
+      - name: Run Integration Tests (TypeScript only)
         working-directory: llama-stack
         env:
           OPENAI_API_KEY: dummy
@@ -110,18 +110,18 @@ jobs:
         run: |
           STACK_CONFIG="server:ci-tests"
 
-          SCRIPT_ARGS="--stack-config $STACK_CONFIG --inference-mode replay"
+          SCRIPT_ARGS="--stack-config $STACK_CONFIG --inference-mode replay --typescript-only"
 
           # Add suite and setup arguments
           SCRIPT_ARGS="$SCRIPT_ARGS --setup ${{ matrix.setup }}"
           SCRIPT_ARGS="$SCRIPT_ARGS --suite ${{ matrix.suite }}"
 
-          echo "=== Running integration tests with TypeScript client ==="
+          echo "=== Running TypeScript client tests only ==="
           echo "Client path: $TS_CLIENT_PATH"
           echo "Command: uv run --no-sync ./scripts/integration-tests.sh $SCRIPT_ARGS"
           echo ""
 
-          uv run --no-sync ./scripts/integration-tests.sh $SCRIPT_ARGS | tee pytest-replay.log
+          uv run --no-sync ./scripts/integration-tests.sh $SCRIPT_ARGS | tee typescript-tests.log
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,208 @@
+name: Integration Tests (Client-side)
+
+run-name: Run integration tests from llama-stack using local TypeScript client
+
+on:
+  push:
+    branches:
+      - main
+      - generated
+      - 'release-[0-9]+.[0-9]+.x'
+  pull_request:
+    branches:
+      - main
+      - generated
+      - 'release-[0-9]+.[0-9]+.x'
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'tests/integration/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/integration-tests.yml'
+  workflow_dispatch:
+    inputs:
+      test-setup:
+        description: 'Test against a specific setup'
+        type: string
+        default: 'ollama'
+
+concurrency:
+  # Skip concurrency for pushes to main - each commit should be tested independently
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout llama-stack repository
+        uses: actions/checkout@v4
+        with:
+          repository: llamastack/llama-stack
+          ref: main
+
+      - name: Generate test matrix
+        id: set-matrix
+        run: |
+          # Generate matrix from CI_MATRIX in llama-stack tests/integration/ci_matrix.json
+          MATRIX=$(PYTHONPATH=. python3 scripts/generate_ci_matrix.py \
+            --test-setup "${{ github.event.inputs.test-setup }}")
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "Generated matrix: $MATRIX"
+
+  run-replay-mode-tests:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    name: ${{ format('Integration Tests (server, {0}, {1})', matrix.config.setup, matrix.config.suite) }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only test server mode - TypeScript client doesn't support library/docker modes
+        client: [server]
+        # Test configurations: Generated from CI_MATRIX in llama-stack tests/integration/ci_matrix.json
+        config: ${{ fromJSON(needs.generate-matrix.outputs.matrix).include }}
+
+    steps:
+      - name: Checkout llama-stack-client-typescript repository
+        uses: actions/checkout@v4
+        with:
+          path: llama-stack-client-typescript
+
+      - name: Checkout llama-stack repository
+        uses: actions/checkout@v4
+        with:
+          repository: llamastack/llama-stack
+          ref: main
+          path: llama-stack
+
+      - name: Check if TypeScript tests exist for this config
+        id: check-ts-tests
+        working-directory: llama-stack
+        run: |
+          # Check if this config allows server client (TypeScript only works with server mode)
+          ALLOWED_CLIENTS='${{ toJSON(matrix.config.allowed_clients) }}'
+          if [[ "$ALLOWED_CLIENTS" != "null" ]] && ! echo "$ALLOWED_CLIENTS" | grep -q "server"; then
+            echo "has_tests=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Config doesn't allow server client, skipping TypeScript tests"
+            exit 0
+          fi
+
+          # Check if this suite/setup combination has TypeScript tests
+          SUITE="${{ matrix.config.suite }}"
+          SETUP="${{ matrix.config.setup }}"
+
+          if [[ ! -f "tests/integration/client-typescript/suites.json" ]]; then
+            echo "has_tests=false" >> $GITHUB_OUTPUT
+            echo "No TypeScript test mapping found"
+            exit 0
+          fi
+
+          # Check if suite/setup is mapped in suites.json
+          HAS_TESTS=$(python3 -c "
+          import json
+          with open('tests/integration/client-typescript/suites.json') as f:
+              suites = json.load(f)
+          for entry in suites:
+              if entry.get('suite') == '$SUITE' and entry.get('setup') == '$SETUP':
+                  print('true')
+                  exit(0)
+          print('false')
+          ")
+
+          echo "has_tests=$HAS_TESTS" >> $GITHUB_OUTPUT
+          if [[ "$HAS_TESTS" == "true" ]]; then
+            echo "✅ TypeScript tests found for suite=$SUITE setup=$SETUP"
+          else
+            echo "⚠️ No TypeScript tests mapped for suite=$SUITE setup=$SETUP"
+          fi
+
+      - name: Set up Node.js
+        if: steps.check-ts-tests.outputs.has_tests == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install uv
+        if: steps.check-ts-tests.outputs.has_tests == 'true'
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+          version: '0.7.6'
+
+      - name: Build TypeScript client
+        if: steps.check-ts-tests.outputs.has_tests == 'true'
+        working-directory: llama-stack-client-typescript
+        run: |
+          echo "Building TypeScript client..."
+          yarn install --frozen-lockfile
+          yarn build
+
+          echo "✅ TypeScript client built successfully"
+
+      - name: Install llama-stack dependencies
+        if: steps.check-ts-tests.outputs.has_tests == 'true'
+        working-directory: llama-stack
+        run: |
+          echo "Installing llama-stack dependencies"
+          uv sync --all-groups
+          uv pip install faiss-cpu
+
+      - name: Build Llama Stack
+        if: steps.check-ts-tests.outputs.has_tests == 'true'
+        working-directory: llama-stack
+        run: |
+          echo "Building Llama Stack"
+          LLAMA_STACK_DIR=. \
+            uv run --no-sync llama stack list-deps ci-tests | xargs -L1 uv pip install
+
+      - name: Configure git for commits
+        if: steps.check-ts-tests.outputs.has_tests == 'true'
+        working-directory: llama-stack
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Check Storage and Memory Available Before Tests
+        if: steps.check-ts-tests.outputs.has_tests == 'true' && always()
+        run: |
+          free -h
+          df -h
+
+      - name: Run Integration Tests (Replay Mode)
+        if: steps.check-ts-tests.outputs.has_tests == 'true'
+        working-directory: llama-stack
+        env:
+          OPENAI_API_KEY: dummy
+          TS_CLIENT_PATH: ${{ github.workspace }}/llama-stack-client-typescript
+        run: |
+          STACK_CONFIG="${{ matrix.config.stack_config || 'server:ci-tests' }}"
+
+          SCRIPT_ARGS="--stack-config $STACK_CONFIG --inference-mode replay"
+
+          # Add optional arguments
+          if [ -n '${{ matrix.config.setup }}' ]; then
+            SCRIPT_ARGS="$SCRIPT_ARGS --setup ${{ matrix.config.setup }}"
+          fi
+          if [ -n '${{ matrix.config.suite }}' ]; then
+            SCRIPT_ARGS="$SCRIPT_ARGS --suite ${{ matrix.config.suite }}"
+          fi
+
+          echo "=== Running integration tests with TypeScript client ==="
+          echo "Client path: $TS_CLIENT_PATH"
+          echo "Command: uv run --no-sync ./scripts/integration-tests.sh $SCRIPT_ARGS"
+          echo ""
+
+          uv run --no-sync ./scripts/integration-tests.sh $SCRIPT_ARGS | tee pytest-replay.log
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ github.run_id }}-${{ github.run_attempt || '1' }}-${{ strategy.job-index || github.job }}-${{ github.action }}
+          path: |
+            llama-stack/*.log
+          retention-days: 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,11 +21,6 @@ on:
       - 'yarn.lock'
       - '.github/workflows/integration-tests.yml'
   workflow_dispatch:
-    inputs:
-      test-setup:
-        description: 'Test against a specific setup'
-        type: string
-        default: 'ollama'
 
 concurrency:
   # Skip concurrency for pushes to main - each commit should be tested independently
@@ -33,38 +28,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  generate-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Checkout llama-stack repository
-        uses: actions/checkout@v4
-        with:
-          repository: llamastack/llama-stack
-          ref: main
-
-      - name: Generate test matrix
-        id: set-matrix
-        run: |
-          # Generate matrix from CI_MATRIX in llama-stack tests/integration/ci_matrix.json
-          MATRIX=$(PYTHONPATH=. python3 scripts/generate_ci_matrix.py \
-            --test-setup "${{ github.event.inputs.test-setup }}")
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
-          echo "Generated matrix: $MATRIX"
-
   run-replay-mode-tests:
-    needs: generate-matrix
     runs-on: ubuntu-latest
-    name: ${{ format('Integration Tests (server, {0}, {1})', matrix.config.setup, matrix.config.suite) }}
+    name: ${{ format('Integration Tests ({0}, {1})', matrix.suite, matrix.setup) }}
 
     strategy:
       fail-fast: false
       matrix:
-        # Only test server mode - TypeScript client doesn't support library/docker modes
-        client: [server]
-        # Test configurations: Generated from CI_MATRIX in llama-stack tests/integration/ci_matrix.json
-        config: ${{ fromJSON(needs.generate-matrix.outputs.matrix).include }}
+        # TypeScript client test configurations
+        # Must match entries in llama-stack/tests/integration/client-typescript/suites.json
+        include:
+          - suite: responses
+            setup: gpt
+          - suite: base
+            setup: ollama
 
     steps:
       - name: Checkout llama-stack-client-typescript repository
@@ -79,62 +56,18 @@ jobs:
           ref: main
           path: llama-stack
 
-      - name: Check if TypeScript tests exist for this config
-        id: check-ts-tests
-        working-directory: llama-stack
-        run: |
-          # Check if this config allows server client (TypeScript only works with server mode)
-          ALLOWED_CLIENTS='${{ toJSON(matrix.config.allowed_clients) }}'
-          if [[ "$ALLOWED_CLIENTS" != "null" ]] && ! echo "$ALLOWED_CLIENTS" | grep -q "server"; then
-            echo "has_tests=false" >> $GITHUB_OUTPUT
-            echo "⚠️ Config doesn't allow server client, skipping TypeScript tests"
-            exit 0
-          fi
-
-          # Check if this suite/setup combination has TypeScript tests
-          SUITE="${{ matrix.config.suite }}"
-          SETUP="${{ matrix.config.setup }}"
-
-          if [[ ! -f "tests/integration/client-typescript/suites.json" ]]; then
-            echo "has_tests=false" >> $GITHUB_OUTPUT
-            echo "No TypeScript test mapping found"
-            exit 0
-          fi
-
-          # Check if suite/setup is mapped in suites.json
-          HAS_TESTS=$(python3 -c "
-          import json
-          with open('tests/integration/client-typescript/suites.json') as f:
-              suites = json.load(f)
-          for entry in suites:
-              if entry.get('suite') == '$SUITE' and entry.get('setup') == '$SETUP':
-                  print('true')
-                  exit(0)
-          print('false')
-          ")
-
-          echo "has_tests=$HAS_TESTS" >> $GITHUB_OUTPUT
-          if [[ "$HAS_TESTS" == "true" ]]; then
-            echo "✅ TypeScript tests found for suite=$SUITE setup=$SETUP"
-          else
-            echo "⚠️ No TypeScript tests mapped for suite=$SUITE setup=$SETUP"
-          fi
-
       - name: Set up Node.js
-        if: steps.check-ts-tests.outputs.has_tests == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install uv
-        if: steps.check-ts-tests.outputs.has_tests == 'true'
         uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
           version: '0.7.6'
 
       - name: Build TypeScript client
-        if: steps.check-ts-tests.outputs.has_tests == 'true'
         working-directory: llama-stack-client-typescript
         run: |
           echo "Building TypeScript client..."
@@ -144,7 +77,6 @@ jobs:
           echo "✅ TypeScript client built successfully"
 
       - name: Install llama-stack dependencies
-        if: steps.check-ts-tests.outputs.has_tests == 'true'
         working-directory: llama-stack
         run: |
           echo "Installing llama-stack dependencies"
@@ -152,7 +84,6 @@ jobs:
           uv pip install faiss-cpu
 
       - name: Build Llama Stack
-        if: steps.check-ts-tests.outputs.has_tests == 'true'
         working-directory: llama-stack
         run: |
           echo "Building Llama Stack"
@@ -160,36 +91,30 @@ jobs:
             uv run --no-sync llama stack list-deps ci-tests | xargs -L1 uv pip install
 
       - name: Configure git for commits
-        if: steps.check-ts-tests.outputs.has_tests == 'true'
         working-directory: llama-stack
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
       - name: Check Storage and Memory Available Before Tests
-        if: steps.check-ts-tests.outputs.has_tests == 'true' && always()
+        if: always()
         run: |
           free -h
           df -h
 
       - name: Run Integration Tests (Replay Mode)
-        if: steps.check-ts-tests.outputs.has_tests == 'true'
         working-directory: llama-stack
         env:
           OPENAI_API_KEY: dummy
           TS_CLIENT_PATH: ${{ github.workspace }}/llama-stack-client-typescript
         run: |
-          STACK_CONFIG="${{ matrix.config.stack_config || 'server:ci-tests' }}"
+          STACK_CONFIG="server:ci-tests"
 
           SCRIPT_ARGS="--stack-config $STACK_CONFIG --inference-mode replay"
 
-          # Add optional arguments
-          if [ -n '${{ matrix.config.setup }}' ]; then
-            SCRIPT_ARGS="$SCRIPT_ARGS --setup ${{ matrix.config.setup }}"
-          fi
-          if [ -n '${{ matrix.config.suite }}' ]; then
-            SCRIPT_ARGS="$SCRIPT_ARGS --suite ${{ matrix.config.suite }}"
-          fi
+          # Add suite and setup arguments
+          SCRIPT_ARGS="$SCRIPT_ARGS --setup ${{ matrix.setup }}"
+          SCRIPT_ARGS="$SCRIPT_ARGS --suite ${{ matrix.suite }}"
 
           echo "=== Running integration tests with TypeScript client ==="
           echo "Client path: $TS_CLIENT_PATH"


### PR DESCRIPTION
Add GitHub Actions workflow to run integration tests against the llama-stack server using pre-recorded API responses. 

The workflow builds the local client and installs it into llama-stack's test environment via `TS_CLIENT_PATH`, then runs llama-stack's integration test script in replay mode. 

